### PR TITLE
Added flex width

### DIFF
--- a/lib/flutter_split_view.dart
+++ b/lib/flutter_split_view.dart
@@ -16,6 +16,16 @@ typedef PageBuilder = Page Function({
   bool? fullscreenDialog,
 });
 
+class FlexWidth {
+  final int mainViewFlexWidth;
+  final int secondaryViewFlexWidth;
+
+  const FlexWidth({
+    required this.mainViewFlexWidth,
+    required this.secondaryViewFlexWidth
+  });
+}
+
 MaterialPage<void> _materialPageBuilder({
   required LocalKey key,
   required Widget child,
@@ -75,6 +85,7 @@ class SplitView extends StatefulWidget {
     this.childWidth = _kDefaultWidth,
     this.breakpoint = _kDefaultBreakpoint,
     this.placeholder,
+    this.flexWidth,
     this.title,
   })  : pageBuilder = _materialPageBuilder,
         super(key: key);
@@ -85,6 +96,7 @@ class SplitView extends StatefulWidget {
     this.childWidth = _kDefaultWidth,
     this.breakpoint = _kDefaultBreakpoint,
     this.placeholder,
+    this.flexWidth,
     this.title,
   })  : pageBuilder = _cupertinoPageBuilder,
         super(key: key);
@@ -95,6 +107,7 @@ class SplitView extends StatefulWidget {
     this.childWidth = _kDefaultWidth,
     this.breakpoint = _kDefaultBreakpoint,
     this.placeholder,
+    this.flexWidth,
     this.title,
     required this.pageBuilder,
   }) : super(key: key);
@@ -113,6 +126,10 @@ class SplitView extends StatefulWidget {
 
   /// Width of the child when it is in the main view.
   final double childWidth;
+
+  /// Width of the child when it is in the main view. If set the SizedBox will be
+  /// replaced with an Extended widget
+  final FlexWidth? flexWidth;
 
   /// Title of the root page, used for the back button in Cupertino.
   final String? title;
@@ -158,17 +175,27 @@ class SplitViewState extends State<SplitView> {
 
         return Row(
           children: <Widget>[
-            SizedBox(
+            if (widget.flexWidth == null) SizedBox(
               width: widget.childWidth,
               child: Navigator(
                 pages: [_pages.first],
                 onPopPage: _onPopPage,
               ),
             ),
-            const VerticalDivider(
+            if (widget.flexWidth != null) Expanded(
+              flex: widget.flexWidth!.mainViewFlexWidth,
+              child: Navigator(
+                pages: [_pages.first],
+                onPopPage: _onPopPage,
+              ),
+            ),
+            if (!(widget.hideDivider == true)) const VerticalDivider(
               width: 0,
             ),
             Expanded(
+              flex: widget.flexWidth != null  
+                ? widget.flexWidth!.secondaryViewFlexWidth
+                : 1,
               child: ClipRect(
                 clipBehavior: Clip.hardEdge,
                 child: _buildSecondaryView(),


### PR DESCRIPTION
Added a new flexWidth parameter which allows the developer to use a dynamic width for the primary view. 

##### Created a new ``FlexWidth`` class which has two parameters. 
- ``mainViewFlexWidth`` which sets the ``flex``param for the primary view ``Expanded`` widget
- ``secondaryViewFlexWidth`` which sets the ``flex``param for the secondary view ``Expanded`` widget

##### Added a new optional parameter ``flexWidth`` 
This parameter receives ``FlexWidth`` value.
If this parameter is set, the ``Expanded``widget will be used as a wrapper for the mainView instead of the ``SizedBox``.